### PR TITLE
7 switch to using spaces rather than tabs for indents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Updated
+
+- eslint rule `indent` to enforce 2 spaces instead of tab characters ([#7](https://github.com/JBKLabs/eslint-config/issues/7))
+
 ## [0.0.12] - 2019-09-24
 
 ### Fixed

--- a/config/stylistic.yml
+++ b/config/stylistic.yml
@@ -8,7 +8,7 @@ rules:
   key-spacing: [error, { beforeColon: false, afterColon: true, mode: strict }]
   comma-spacing: [error, { before: false, after: true }]
   comma-dangle: [error, never]
-  indent: [error, tab]
+  indent: [error, 2]
   no-trailing-spaces: error
   no-array-constructor: error
   array-bracket-newline: [error, { multiline: true }]


### PR DESCRIPTION
Closes #7 

## Changes

- update `indent` rule to enforce 2 spaces instead of tab

## Steps to Test

* [ ] verify eslint configuration works as intended
